### PR TITLE
Adding NBT tags for model data utilization

### DIFF
--- a/src/mc/ajneb97/juego/Tablero.java
+++ b/src/mc/ajneb97/juego/Tablero.java
@@ -158,42 +158,40 @@ public class Tablero {
 		}
 		
 		if(tipo.equals("torre")) {
-			l.getBlock().setType(m);
-			l.clone().add(0,1,0).getBlock().setType(m);
-			Location l2 = l.clone().add(0,2,0);
-			Utilidades.setSkullBlock(l2, "5e193aa2-292e-43c6-b92b-e823f6e0cc1e", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZjQ1NTlkNzU0NjRiMmU0MGE1MThlNGRlOGU2Y2YzMDg1ZjBhM2NhMGIxYjcwMTI2MTRjNGNkOTZmZWQ2MDM3OCJ9fX0=", rot);
-		}else if(tipo.equals("caballo")) {
-			l.getBlock().setType(m);
-			l.clone().add(0,1,0).getBlock().setType(m);
-			Location l2 = l.clone().add(0,2,0);
-			Utilidades.setSkullBlock(l2, "022202fd-9546-4492-b8b6-b768e95701c2", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvN2JiNGIyODg5OTFlZmI4Y2EwNzQzYmVjY2VmMzEyNThiMzFkMzlmMjQ5NTFlZmIxYzljMThhNDE3YmE0OGY5In19fQ==", rot);
-		}else if(tipo.equals("alfil")) {
-			l.getBlock().setType(m);
-			l.clone().add(0,1,0).getBlock().setType(m);
-			Location l2 = l.clone().add(0,2,0);
 			if(color.equals("b")) {
-				Utilidades.setSkullBlock(l2, "eb1fc1a8-763e-442f-bf10-302b3beebb32", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMTI2Yjc3MjMyOWNmMzJmODY0M2M0OTI4NjI2YjZhMzI1MjMzZmY2MWFhOWM3NzI1ODczYTRiZDY2ZGIzZDY5MiJ9fX0=", rot);
+				l.getBlock().setType(m).customModelData(101);
 			}else {
-				Utilidades.setSkullBlock(l2, "c766a367-5d10-4b8f-a2fe-d3796bfbfcc1", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZDdmNTc2NmQyOTI4ZGMwZGYxYjM0MDRjM2JkMDczYzk0NzZkMjZjODA1NzNiMDMzMmU3Y2NlNzNkZjE1NDgyYSJ9fX0=", rot);
+				l.getBlock().setType(m).customModelData(107);
+			}
+		}else if(tipo.equals("caballo")) {
+			if(color.equals("b")) {
+				l.getBlock().setType(m).customModelData(102);
+			}else {
+				l.getBlock().setType(m).customModelData(108);
+			}
+		}else if(tipo.equals("alfil")) {
+			if(color.equals("b")) {
+				l.getBlock().setType(m).customModelData(103);
+			}else {
+				l.getBlock().setType(m).customModelData(109);
 			}
 		}else if(tipo.equals("rey")) {
-			l.getBlock().setType(m);
-			l.clone().add(0,1,0).getBlock().setType(m);
-			l.clone().add(0,2,0).getBlock().setType(m);
-			l.clone().add(0,3,0).getBlock().setType(Material.DIAMOND_BLOCK);
-		}else if(tipo.equals("reina")) {
-			l.getBlock().setType(m);
-			l.clone().add(0,1,0).getBlock().setType(m);
-			l.clone().add(0,2,0).getBlock().setType(m);
-			Location l2 = l.clone().add(0,3,0);
-			Utilidades.setSkullBlock(l2, "fdea850d-ae8b-4e10-8b03-6883494ae266", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNTRiZjg5M2ZjNmRlZmFkMjE4Zjc4MzZlZmVmYmU2MzZmMWMyY2MxYmI2NTBjODJmY2NkOTlmMmMxZWU2In19fQ==", rot);
-		}else if(tipo.equals("peon")) {
-			l.getBlock().setType(m);
-			Location l2 = l.clone().add(0,1,0);
 			if(color.equals("b")) {
-				Utilidades.setSkullBlock(l2, "eb1fc1a8-763e-442f-bf10-302b3beebb32", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMTI2Yjc3MjMyOWNmMzJmODY0M2M0OTI4NjI2YjZhMzI1MjMzZmY2MWFhOWM3NzI1ODczYTRiZDY2ZGIzZDY5MiJ9fX0=", rot);
+				l.getBlock().setType(m).customModelData(104);
 			}else {
-				Utilidades.setSkullBlock(l2, "c766a367-5d10-4b8f-a2fe-d3796bfbfcc1", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZDdmNTc2NmQyOTI4ZGMwZGYxYjM0MDRjM2JkMDczYzk0NzZkMjZjODA1NzNiMDMzMmU3Y2NlNzNkZjE1NDgyYSJ9fX0=", rot);
+				l.getBlock().setType(m).customModelData(110);
+			}
+		}else if(tipo.equals("reina")) {
+			if(color.equals("b")) {
+				l.getBlock().setType(m).customModelData(105);
+			}else {
+				l.getBlock().setType(m).customModelData(111);
+			}
+		}else if(tipo.equals("peon")) {
+			if(color.equals("b")) {
+				l.getBlock().setType(m).customModelData(100);
+			}else {
+				l.getBlock().setType(m).customModelData(106);
 			}
 		}
 	}


### PR DESCRIPTION
This is more of a personalized build in which I replace the default spawning of the chess pieces with blocks that contain NBT tag data so that they can be recognized by model plugins that utilize this, enabling me to import custom chess piece models into the plugin.

In this build, I change all piece spawns to single blocks rather than multiple blocks, and tag them with customModelData, so that they may be recognized and swapped out for other models that I have made myself.

Model data for individual pieces is as follows:
All white pieces are IRON_BLOCK
All black pieces are COAL_BLOCK
Pawns;
  White (100)  Black (106)
Rooks;
  White (101)  Black (107)
Knights;
  White (102)  Black (108)
Bishops;
  White (103)  Black (109)
Kings;
  White (104)  Black (110)
Queens;
  White (105)  Black (111)

*Note that if you try to use this build and you do not have a model handler plugin that utilizes customModelData (NBT) tags [Oraxen, for example], it will not work, and all piece spawns will look identical and be only 1 block tall. This means that this build requires the user to be using a model handler plugin in that can handle custom model data in order for it to work

**Also note that I am a beginner with this sort of thing, so I do not expect this to work without some trial and error, necessarily.